### PR TITLE
4844: update point evaluation precompile address to 0x0A

### DIFF
--- a/core/vm/contracts.go
+++ b/core/vm/contracts.go
@@ -115,7 +115,7 @@ var PrecompiledContractsDanksharding = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{7}):  &bn256ScalarMulIstanbul{},
 	common.BytesToAddress([]byte{8}):  &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{9}):  &blake2F{},
-	common.BytesToAddress([]byte{20}): &pointEvaluation{},
+	common.BytesToAddress([]byte{10}): &pointEvaluation{},
 }
 
 var (

--- a/core/vm/contracts_test.go
+++ b/core/vm/contracts_test.go
@@ -56,17 +56,16 @@ var allPrecompiles = map[common.Address]PrecompiledContract{
 	common.BytesToAddress([]byte{7}):    &bn256ScalarMulIstanbul{},
 	common.BytesToAddress([]byte{8}):    &bn256PairingIstanbul{},
 	common.BytesToAddress([]byte{9}):    &blake2F{},
-	common.BytesToAddress([]byte{10}):   &bls12381G1Add{},
-	common.BytesToAddress([]byte{11}):   &bls12381G1Mul{},
-	common.BytesToAddress([]byte{12}):   &bls12381G1MultiExp{},
-	common.BytesToAddress([]byte{13}):   &bls12381G2Add{},
-	common.BytesToAddress([]byte{14}):   &bls12381G2Mul{},
-	common.BytesToAddress([]byte{15}):   &bls12381G2MultiExp{},
-	common.BytesToAddress([]byte{16}):   &bls12381Pairing{},
-	common.BytesToAddress([]byte{17}):   &bls12381MapG1{},
-	common.BytesToAddress([]byte{18}):   &bls12381MapG2{},
-	// TODO: this might change to 19 later. Avoiding precompile address changes / EIP collisions for now by keeping 20 (0x14).
-	common.BytesToAddress([]byte{20}): &pointEvaluation{},
+	common.BytesToAddress([]byte{10}):   &pointEvaluation{},
+	// common.BytesToAddress([]byte{10}):   &bls12381G1Add{},
+	common.BytesToAddress([]byte{11}): &bls12381G1Mul{},
+	common.BytesToAddress([]byte{12}): &bls12381G1MultiExp{},
+	common.BytesToAddress([]byte{13}): &bls12381G2Add{},
+	common.BytesToAddress([]byte{14}): &bls12381G2Mul{},
+	common.BytesToAddress([]byte{15}): &bls12381G2MultiExp{},
+	common.BytesToAddress([]byte{16}): &bls12381Pairing{},
+	common.BytesToAddress([]byte{17}): &bls12381MapG1{},
+	common.BytesToAddress([]byte{18}): &bls12381MapG2{},
 }
 
 // EIP-152 test vectors


### PR DESCRIPTION
I updated the 4844 point evaluation precompile address so that I could verify my rebase for ethereum/execution-spec-tests/pull/203 due to ethereum/execution-spec-tests/pull/171.

The changes are fine for filling tests, but I was unsure how to resolve the address collision in core/vm/contracts_test.go; perhaps it's not relevant for this branch?
