### PR TITLE
disable tx marshalling for the type 3 to field

### DIFF
--- a/core/types/transaction_marshalling.go
+++ b/core/types/transaction_marshalling.go
@@ -332,11 +332,13 @@ func (tx *Transaction) UnmarshalJSON(input []byte) error {
 		if dec.Nonce == nil {
 			return errors.New("missing required field 'nonce' in transaction")
 		}
-		itx.Nonce = uint64(*dec.Nonce)
-		if dec.To == nil {
-			return errors.New("missing required field 'to' in transaction")
-		}
-		itx.To = *dec.To
+		/*
+			itx.Nonce = uint64(*dec.Nonce)
+			if dec.To == nil {
+				return errors.New("missing required field 'to' in transaction")
+			}
+			itx.To = *dec.To
+		*/
 		if dec.Gas == nil {
 			return errors.New("missing required field 'gas' for txdata")
 		}


### PR DESCRIPTION
To try and allow fixture generation for testing that a type 3 tx can't set to to `nil`, respectively create a contract.