### PR TITLE
write verkle conversion and ascii to stderr instead of stdout

### DIFF
--- a/core/overlay/conversion.go
+++ b/core/overlay/conversion.go
@@ -225,7 +225,7 @@ func OverlayVerkleTransition(statedb *state.StateDB, root common.Hash, maxMovedC
 	// verkle transition: if the conversion process is in progress, move
 	// N values from the MPT into the verkle tree.
 	if migrdb.InTransition() {
-		fmt.Printf("Processing verkle conversion starting at %x %x, building on top of %x\n", migrdb.GetCurrentAccountHash(), migrdb.GetCurrentSlotHash(), root)
+		fmt.Fprintf(os.Stderr, "Processing verkle conversion starting at %x %x, building on top of %x\n", migrdb.GetCurrentAccountHash(), migrdb.GetCurrentSlotHash(), root)
 		var (
 			now             = time.Now()
 			tt              = statedb.GetTrie().(*trie.TransitionTrie)

--- a/core/state/database.go
+++ b/core/state/database.go
@@ -19,6 +19,7 @@ package state
 import (
 	"errors"
 	"fmt"
+	"os"
 
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/lru"
@@ -218,7 +219,7 @@ func (db *cachingDB) Transitioned() bool {
 
 // Fork implements the fork
 func (db *cachingDB) StartVerkleTransition(originalRoot, translatedRoot common.Hash, chainConfig *params.ChainConfig, pragueTime *uint64, root common.Hash) {
-	fmt.Println(`
+	fmt.Fprintf(os.Stderr, `
 	__________.__                       .__                .__                   __       .__                               .__          ____         
 	\__    ___|  |__   ____        ____ |  |   ____ ______ |  |__ _____    _____/  |_     |  |__ _____    ______    __  _  _|__| ____   / ___\ ______
 	  |    |  |  |  \_/ __ \     _/ __ \|  | _/ __ \\____ \|  |  \\__  \  /    \   __\    |  |  \\__  \  /  ___/    \ \/ \/ |  |/    \ / /_/  /  ___/
@@ -255,7 +256,7 @@ func (db *cachingDB) EndVerkleTransition() {
 		db.CurrentTransitionState.started = true
 	}
 
-	fmt.Println(`
+	fmt.Fprintf(os.Stderr, `
 	__________.__                       .__                .__                   __       .__                       .__                    .___         .___
 	\__    ___|  |__   ____        ____ |  |   ____ ______ |  |__ _____    _____/  |_     |  |__ _____    ______    |  | _____    ____   __| _/____   __| _/
 	  |    |  |  |  \_/ __ \     _/ __ \|  | _/ __ \\____ \|  |  \\__  \  /    \   __\    |  |  \\__  \  /  ___/    |  | \__  \  /    \ / __ _/ __ \ / __ |


### PR DESCRIPTION
Currently, upon transition to Verkle the elephant ascii and info line gets printed to stdout, this messes up `evm t8n` as it expects stdout to only contain the json response from `evm`.

This PR writes these lines to stderr instead. 

![image](https://github.com/marioevz/go-ethereum/assets/91727015/23ddb787-31d7-4e45-b1d3-817d85f2063d)
